### PR TITLE
Removed check for domain name after HELO/EHLO

### DIFF
--- a/Simple.MailServer/Smtp/SmtpSessionInfoResponder.cs
+++ b/Simple.MailServer/Smtp/SmtpSessionInfoResponder.cs
@@ -65,11 +65,6 @@ namespace Simple.MailServer.Smtp
 
         protected override SmtpResponse ProcessCommandEhlo(string name, string arguments)
         {
-            if (String.IsNullOrWhiteSpace(arguments))
-            {
-                return SmtpResponses.EhloMissingDomainAddress;
-            }
-
             var identification = new SmtpIdentification(SmtpIdentificationMode.EHLO, arguments);
             var response = _responderFactory.IdentificationResponder.VerifyIdentification(SessionInfo, identification);
 
@@ -83,11 +78,6 @@ namespace Simple.MailServer.Smtp
 
         protected override SmtpResponse ProcessCommandHelo(string name, string arguments)
         {
-            if (String.IsNullOrWhiteSpace(arguments))
-            {
-                return SmtpResponses.HeloMissingDomainAddress;
-            }
-
             var identification = new SmtpIdentification(SmtpIdentificationMode.HELO, arguments);
             var response = _responderFactory.IdentificationResponder.VerifyIdentification(SessionInfo, identification);
 


### PR DESCRIPTION
Hello,

Thank you very much for your clear and easy-to-use SMTP server! I am using your code for getting error messages from a Danfoss Drive. I hit one snag, though: The drive does not give a domain name after the HELO command. This makes Simple.Mailserver return 501 Failure.

Sending the domain as ID after HELO is not a hard requirement from the RFC2821 section 4.1.1.1 (client SHOULD send domain name or other identification), so I suggest the removal of these checks from the code base. This pull request simply removes the checks for both HELO and EHLO, allowing SessionInfo.Identification to be null in this case. I will gladly rewrite the change to another form, e.g. a string with content "unknown" if you think it more appropriate - or you are free to disregard it completely, of course :-)

Best regards,

```
     /Niels Holmgaard
```
