### PR TITLE
Fix critical bug, related sending data to unexpectedly closed connection

### DIFF
--- a/Simple.MailServer/Smtp/SmtpServer.cs
+++ b/Simple.MailServer/Smtp/SmtpServer.cs
@@ -183,7 +183,13 @@ namespace Simple.MailServer.Smtp
             Connections[connection.RemoteEndPoint] = connection;
             ClientConnected(this, new SmtpConnectionEventArgs(connection));
 
-            await CreateSessionAndProcessCommands(connection);
+            try
+            {
+                await CreateSessionAndProcessCommands(connection);
+            } catch(Exception ex)
+            {
+                MailServerLogger.Instance.Error(ex);
+            }
         }
 
         private async Task CreateSessionAndProcessCommands(SmtpConnection connection)
@@ -237,10 +243,17 @@ namespace Simple.MailServer.Smtp
         {
             LogResponse(response);
 
-            foreach (var additional in response.AdditionalLines)
-                await connection.WriteLineAsyncAndFireEvents(additional);
+            try
+            {
+                foreach (var additional in response.AdditionalLines)
+                    await connection.WriteLineAsyncAndFireEvents(additional);
 
-            await connection.WriteLineAsyncAndFireEvents(response.ResponseCode + " " + response.ResponseText);
+                await connection.WriteLineAsyncAndFireEvents(response.ResponseCode + " " + response.ResponseText);
+
+            } catch(Exception ex)
+            {
+                MailServerLogger.Instance.Error(ex);
+            }
         }
 
         private static void LogResponse(SmtpResponse response)


### PR DESCRIPTION
Hello, firstly thank you for the very good project. 

The main process terminated when a thread tried to send data to a connection that was already closed. 
I experienced the issue in a production environment, so I suppose the fix could be useful. I think it occurs because of bots.  
